### PR TITLE
Support lune 0.10

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -1,6 +1,6 @@
 {
   "aliases": {
-    "lune": "~/.lune/.typedefs/0.8.9/"
+    "lune": "~/.lune/.typedefs/0.10.2/"
   },
   "languageMode": "strict"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,2 @@
 {
-  "luau-lsp.require.useOriginalRequireByStringSemantics": true
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # glob-lune
 `glob` implementation in luau for lune runtime heavily inspired by [glob](https://www.npmjs.com/package/glob)
 
+## Prerequisites
+- **pesde**: `^0.10.2`
+- **lune**: `^0.7.1`
+
 ## Installation
 Install via pesde (Recommended)
 ```sh

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+[settings]
+experimental = true
+
+[tools]
+"github:JohnnyMorganz/StyLua" = "latest"
+"github:JohnnyMorganz/luau-lsp" = "latest"
+"github:Kampfkarren/selene" = "latest"
+node = "latest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,9 +71,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -98,9 +98,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",

--- a/pesde.lock
+++ b/pesde.lock
@@ -5,59 +5,55 @@ name = "jiwonz/glob"
 version = "0.1.2"
 target = "lune"
 
-[graph."corecii/greentea@0.4.11 lune".pkg_ref]
-ref_ty = "pesde"
-index_url = "https://github.com/daimond113/pesde-index"
-
-[graph."jiwonz/luau_disk@0.1.4 luau".pkg_ref]
+[graph."jiwonz/greentea_luau@0.2.0 luau".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/luau_path@0.1.4 luau".dependencies]
-luau_disk = ["jiwonz/luau_disk@0.1.4 luau", "standard"]
-
-[graph."jiwonz/luau_path@0.1.4 luau".pkg_ref]
+[graph."jiwonz/luau_disk@0.2.0 luau".pkg_ref]
 ref_ty = "pesde"
-index_url = "https://github.com/daimond113/pesde-index"
+index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/luau_path@0.1.4 luau".pkg_ref.dependencies]
-luau_disk = [{ name = "jiwonz/luau_disk", version = "^0.1.4", index = "https://github.com/pesde-pkg/index" }, "standard"]
+[graph."jiwonz/luau_path@0.2.0 luau".dependencies]
+luau_disk = ["jiwonz/luau_disk@0.2.0 luau", "standard"]
+
+[graph."jiwonz/luau_path@0.2.0 luau".pkg_ref]
+ref_ty = "pesde"
+index_url = "https://github.com/pesde-pkg/index"
+
+[graph."jiwonz/luau_path@0.2.0 luau".pkg_ref.dependencies]
+luau_disk = [{ name = "jiwonz/luau_disk", version = "^0.2.0", index = "https://github.com/pesde-pkg/index" }, "standard"]
 
 [graph."jiwonz/luau_regexp@0.1.3 luau".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/pathfs@0.6.0-rc.7 lune"]
-direct = ["pathfs", { name = "jiwonz/pathfs", version = "^0.6.0-rc.3", index = "default" }, "standard"]
+[graph."jiwonz/pathfs@0.6.0 lune"]
+direct = ["pathfs", { name = "jiwonz/pathfs", version = "^0.6.0", index = "default" }, "standard"]
 
-[graph."jiwonz/pathfs@0.6.0-rc.7 lune".dependencies]
-greentea = ["corecii/greentea@0.4.11 lune", "standard"]
-luau_path = ["jiwonz/luau_path@0.1.4 luau", "standard"]
+[graph."jiwonz/pathfs@0.6.0 lune".dependencies]
+greentea = ["jiwonz/greentea_luau@0.2.0 luau", "standard"]
+luau_path = ["jiwonz/luau_path@0.2.0 luau", "standard"]
 
-[graph."jiwonz/pathfs@0.6.0-rc.7 lune".pkg_ref]
+[graph."jiwonz/pathfs@0.6.0 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/pathfs@0.6.0-rc.7 lune".pkg_ref.dependencies]
-frktest = [{ name = "itsfrank/frktest", version = "^0.0.2", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-greentea = [{ name = "corecii/greentea", version = "^0.4.11", index = "https://github.com/daimond113/pesde-index" }, "standard"]
-luau_check = [{ name = "jiwonz/luau_check", version = "^0.3.13", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.48.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-luau_path = [{ name = "jiwonz/luau_path", version = "^0.1.4", index = "https://github.com/daimond113/pesde-index", target = "luau" }, "standard"]
-selene = [{ name = "pesde/selene", version = "^0.28.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
-stylua = [{ name = "pesde/stylua", version = "^2.1.0", index = "https://github.com/daimond113/pesde-index" }, "dev"]
+[graph."jiwonz/pathfs@0.6.0 lune".pkg_ref.dependencies]
+frktest = [{ name = "itsfrank/frktest", version = "^0.0.4", index = "https://github.com/pesde-pkg/index", target = "luau" }, "dev"]
+greentea = [{ name = "jiwonz/greentea_luau", version = "^0.2.0", index = "https://github.com/pesde-pkg/index", target = "luau" }, "standard"]
+luau_path = [{ name = "jiwonz/luau_path", version = "^0.2.0", index = "https://github.com/pesde-pkg/index", target = "luau" }, "standard"]
 
-[graph."kimpure/globrex_lune@0.2.4 lune"]
-direct = ["globrex_lune", { name = "kimpure/globrex_lune", version = "^0.2.4", index = "default" }, "standard"]
+[graph."kimpure/globrex_lune@0.2.9 lune"]
+direct = ["globrex_lune", { name = "kimpure/globrex_lune", version = "^0.2.9", index = "default" }, "standard"]
 
-[graph."kimpure/globrex_lune@0.2.4 lune".dependencies]
+[graph."kimpure/globrex_lune@0.2.9 lune".dependencies]
 luau_regexp = ["jiwonz/luau_regexp@0.1.3 luau", "standard"]
 
-[graph."kimpure/globrex_lune@0.2.4 lune".pkg_ref]
+[graph."kimpure/globrex_lune@0.2.9 lune".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."kimpure/globrex_lune@0.2.4 lune".pkg_ref.dependencies]
+[graph."kimpure/globrex_lune@0.2.9 lune".pkg_ref.dependencies]
 luau_check = [{ name = "jiwonz/luau_check", version = "^0.2.2", index = "https://github.com/pesde-pkg/index" }, "dev"]
 luau_lsp = [{ name = "pesde/luau_lsp", version = "^1.38.1", index = "https://github.com/pesde-pkg/index" }, "dev"]
 luau_regexp = [{ name = "jiwonz/luau_regexp", version = "^0.1.0", index = "https://github.com/pesde-pkg/index", target = "luau" }, "standard"]

--- a/pesde.toml
+++ b/pesde.toml
@@ -14,9 +14,9 @@ lib = "src/lib.luau"
 default = "https://github.com/pesde-pkg/index"
 
 [engines]
-lune = "^0.9.4"
-pesde = "^0.7.0-rc.1"
+lune = "^0.10.2"
+pesde = "^0.7.1"
 
 [dependencies]
-globrex_lune = { name = "kimpure/globrex_lune", version = "^0.2.4" }
-pathfs = { name = "jiwonz/pathfs", version = "^0.6.0-rc.3" }
+globrex_lune = { name = "kimpure/globrex_lune", version = "^0.2.9" }
+pathfs = { name = "jiwonz/pathfs", version = "^0.6.0" }

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,9 +1,0 @@
-# This file lists tools managed by Rokit, a toolchain manager for Roblox projects.
-# For more information, see https://github.com/rojo-rbx/rokit
-
-# New tools can be added by running `rokit add <tool>` in a terminal.
-
-[tools]
-selene = "Kampfkarren/selene@0.29.0"
-luau-lsp = "JohnnyMorganz/luau-lsp@1.53.1"
-StyLua = "JohnnyMorganz/StyLua@2.1.0"


### PR DESCRIPTION
Closes #6 

Some notes
- Add support for Lune 0.10 by updating packages and Test was successful in Lune 0.10 with an example
- Remove the setting which is for old require semantics for luau-lsp vscode extension
- Fix npm package audit (for glob test in js)
- Use mise instead of rokit and Add node version management
- Add prerequisites